### PR TITLE
Treat “Return” the same as DoubleClick.

### DIFF
--- a/ClipBoard/MainForm.Designer.cs
+++ b/ClipBoard/MainForm.Designer.cs
@@ -70,6 +70,7 @@
             this.listView.View = System.Windows.Forms.View.Details;
             this.listView.DoubleClick += new System.EventHandler(this.listView_DoubleClick);
             this.listView.MouseClick += new System.Windows.Forms.MouseEventHandler(this.listView_MouseClick);
+            this.listView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listView_KeyDown);
             // 
             // indexColumnHeader
             // 

--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -148,7 +148,20 @@ namespace ClipBoard
             list.Columns[1].Width = this.list.Width - 50;
         }
 
-        private async void listView_DoubleClick(object sender, EventArgs e)
+        private void listView_DoubleClick(object sender, EventArgs e)
+        {
+            copyTextToClipboardAndPaste();
+        }
+ 
+        private void listView_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode == Keys.Return)
+            {
+                copyTextToClipboardAndPaste();
+            }
+        }
+ 
+        private async void copyTextToClipboardAndPaste()
         {
             copyTextToClipBoard();
 

--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -200,7 +200,7 @@ namespace ClipBoard
             }
             else if (e.Button == System.Windows.Forms.MouseButtons.Left)
             {
-                this.listView_DoubleClick(sender, e);
+                copyTextToClipboardAndPaste();
             }
         }
 


### PR DESCRIPTION
Treat “Return” the same as DoubleClick as this allows navigating through the list via the arrow keys and then return will confirm the selection.
