### PR TITLE
Workaround for Notepad++ paste problem (Issue #6) and enhanced content.csv file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,7 +97,7 @@ publish/
 
 # NuGet Packages Directory
 ## TODO: If you have NuGet Package Restore enabled, uncomment the next line
-#packages/
+packages/
 
 # Windows Azure Build Output
 csx

--- a/ClipBoard/ClipBoard.csproj
+++ b/ClipBoard/ClipBoard.csproj
@@ -64,6 +64,9 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsInput, Version=1.0.4.0, Culture=neutral, PublicKeyToken=9b287f7dc5073cad, processorArchitecture=MSIL">
+      <HintPath>..\packages\InputSimulator.1.0.4.0\lib\net20\WindowsInput.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ClipBoardRecord.cs" />
@@ -88,6 +91,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <None Include="content.csv" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -13,7 +13,7 @@ namespace ClipBoard
     public partial class MainForm : Form
     {
         public ListView list;
-        private static string contentFileName = "content.csv";
+        private static string contentFileName = Program.ContentFileName;
         private static int maxCopyTextLength = 10000;
         private List<ClipBoardRecord> savedItems;
         private List<ClipBoardRecord> frequentItems;
@@ -155,6 +155,12 @@ namespace ClipBoard
                         break;
                     }
                 }
+
+                if (!Directory.Exists(Path.GetDirectoryName(contentFileName)))
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(contentFileName));
+                }
+
                 File.WriteAllLines(contentFileName, lines);
             }        
         }

--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -5,6 +5,8 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using WindowsInput;
+using WindowsInput.Native;
 
 namespace ClipBoard
 {
@@ -325,7 +327,8 @@ namespace ClipBoard
 
             // paste to curreMonkey talk font cursor
             await Task.Delay(500);
-            SendKeys.Send("^V");
+            var inputSimulator = new InputSimulator();
+            inputSimulator.Keyboard.ModifiedKeyStroke(VirtualKeyCode.CONTROL, VirtualKeyCode.VK_V);            
         }
 
         private void copyTextToClipBoard()

--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -166,7 +166,7 @@ namespace ClipBoard
         {
             this.Height = (listView.Items.Count * listView.Items[0].Bounds.Height)
                                 + (listView.Groups.Count * listView.GetItemRect(0).Height)
-                                + ((listView.Items.Count) + 25);
+                                + ((listView.Items.Count) + 100);
 
             Region = System.Drawing.Region.FromHrgn(CreateRoundRectRgn(0, 0, Width, Height, 20, 20));
             linkLabelGitHub.Top = listView.Top + listView.Height + 5;

--- a/ClipBoard/MainForm.cs
+++ b/ClipBoard/MainForm.cs
@@ -13,7 +13,7 @@ namespace ClipBoard
     public partial class MainForm : Form
     {
         public ListView list;
-        private static string contentFileName = "../../content.csv";
+        private static string contentFileName = "content.csv";
         private static int maxCopyTextLength = 10000;
         private List<ClipBoardRecord> savedItems;
         private List<ClipBoardRecord> frequentItems;
@@ -176,8 +176,8 @@ namespace ClipBoard
         private void loadContent(string contentFileName)
         {
             char[] delimiterChars = { ',' };
-            string[] fileFields;
-            string[] lines = File.ReadAllLines(contentFileName);
+            string[] fileFields;           
+            string[] lines = File.Exists(contentFileName) ? File.ReadAllLines(contentFileName) : new string[] { };
             string type;
 
             foreach (string s in lines)

--- a/ClipBoard/Program.cs
+++ b/ClipBoard/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -16,6 +17,7 @@ namespace ClipBoard
         private static LowLevelKeyboardProc _proc = HookCallback;
         private static IntPtr _hookID = IntPtr.Zero;
         private static MainForm mf;
+        public static string ContentFileName;
 
         /// <summary>
         /// The main entry point for the application.
@@ -23,6 +25,12 @@ namespace ClipBoard
         [STAThread]
         static void Main()
         {
+            // check if a content file has been provided in command line,
+            // otherwise set its name to the users %APDDATA% 
+            var commandLineArgs = Environment.GetCommandLineArgs();
+            ContentFileName = commandLineArgs.Length > 1 ? 
+                commandLineArgs[1] : Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Clipboard//content.csv");
+
             _hookID = SetHook(_proc);
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/ClipBoard/packages.config
+++ b/ClipBoard/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="InputSimulator" version="1.0.4.0" targetFramework="net45" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ tool is written with .Net 4.5 and runs on Windows.
 The tool monitors system keyboard events and copies **text** from system 
 clipboard when a "Copy" is performed.
 
-###Usage
+### Usage
 
 - Click on an item to copy the text to system clipboard and trigger `Ctrl+V`
 - Right click an item to save it to the frequently used items list on the top
@@ -19,4 +19,12 @@ clipboard when a "Copy" is performed.
 
 ![screenshot](https://raw.githubusercontent.com/MrCull/ClipBoard/base/Screenshot/ClipBoard.png)
 
-###Enjoy!
+### Data Storage
+
+By default, your saved text snippets are stored in %APPDATA%\Clipboad\content.csv. This file will be created if it not exists, yet. If you like to use another file in another location you can pass the full filepath as first command line argument to ClipBoard.exe
+
+``ClipBoard.exe D:\MyClipboardContent\content.csv``
+
+You may also drag&drop your data file on ClipBoard.exe in Windows Explorer.
+
+### Enjoy!


### PR DESCRIPTION
I didn't checked the CTRL+V issue  #6 with Outlook yet but I've been able to reproduce this with Notepad++. The reason may be found in this post: http://stackoverflow.com/questions/24600265/paste-current-time-using-global-hotkey-in-c-sharp

As a quick workaround I implemented the InputSimulator via NuGet package (see https://github.com/michaelnoonan/inputsimulator)

Unfortunately, this creates a dependency to an extra DLL which was maybe not your intention. To get rid of this dependency the "USER32.DLL" function SendInput needs to be hooked up as it's done in InputSimulator from within CLIPBOARD code.

Furthermore I've change the file path dependency of content.csv: Clipboard.exe is now able to start without an existing content.csv at all if one doesn't want to start with the "lorem ipsum" list. Default path for content.csv is set to %APPDATA%\Clipboard\content.csv and it will be created, if it doesn't exist.

You can also pass another full file path as first argument to ClipBoard.exe if you'd like to use another file anyway.